### PR TITLE
Allow sections with no content

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -116,7 +116,7 @@ export class ReadmeBox {
   private createRegExp(section: string) {
     const start = `<!--START_SECTION:${section}-->`
     const end = `<!--END_SECTION:${section}-->`
-    const regex = new RegExp(`${start}\n(?<content>[\\s\\S]+)\n${end}`)
+    const regex = new RegExp(`${start}\n(?:(?<content>[\\s\\S]+)\n)?${end}`)
     return { regex, start, end }
   }
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -83,6 +83,14 @@ describe('ReadmeBox', () => {
       const result = box.getSection('nope', fixtures.ReadmeContent)
       expect(result).toBeUndefined()
     })
+
+    it('returns undefined if the section is empty', () => {
+      const result = box.getSection(
+        'example',
+        '<!--START_SECTION:example-->\n<!--END_SECTION:example-->'
+      )
+      expect(result).toBeUndefined()
+    })
   })
 
   describe('#replaceSection', () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -108,5 +108,16 @@ describe('ReadmeBox', () => {
         'Contents do not contain start/end comments for section "example"'
       )
     })
+
+    it('works when the comments are not separated by any content', () => {
+      const result = box.replaceSection({
+        newContents: 'New content!',
+        oldContents: '<!--START_SECTION:example-->\n<!--END_SECTION:example-->',
+        section: 'example'
+      })
+      expect(result).toBe(
+        '<!--START_SECTION:example-->\nNew content!\n<!--END_SECTION:example-->'
+      )
+    })
   })
 })


### PR DESCRIPTION
This fixes a bug where replacing sections with no content (like the below example) would throw an error, because the RegEx doesn't match it:

```html
<!--START_SECTION:example-->
<!--END_SECTION:example-->
```