### PR TITLE
Reverse `emptyCommits` default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ const result = await ReadmeBox.updateSection('New contents!', {
   // branch is assumed to be 'master' by default, you can also specify `branch: 'main'`
   branch: 'main',
   section: 'example-section',
-  // set to false to avoid empty commits in case of no changes
-  emptyCommits: true
+  // set to `true` to allow empty commits when there are no changes
+  emptyCommits: false
 })
 
 // `result` is the response object of the README update request or
-// `undefined` in case there were no changes and `emptyCommits` is set to `false`
+// `undefined` if no changes were made.
 ```
 
 Or, if you need to access parts of it more granularly, you can use the `ReadmeBox` class methods:

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,7 +52,7 @@ export class ReadmeBox {
       newContents
     })
 
-    if (opts.emptyCommits === false && content === replaced) {
+    if (opts.emptyCommits !== true && content === replaced) {
       return
     }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -57,12 +57,18 @@ describe('ReadmeBox', () => {
       expect(updateFileContentsParams.message).toBe(opts.message)
     })
 
-    it('Does not create commit if `emptyCommits` is set to `false` and there are no changes', async () => {
+    it('does commit if `emptyCommits` is set to `true` and there are no changes', async () => {
       const result = await ReadmeBox.updateSection('Old stuff...', {
         ...opts,
-        emptyCommits: false
+        emptyCommits: true
       })
 
+      expect(result).toBeDefined()
+      expect(nock.isDone()).toBe(true)
+    })
+
+    it('does not create commit if `emptyCommits` is not set and there are no changes', async () => {
+      const result = await ReadmeBox.updateSection('Old stuff...', opts)
       expect(result).toBeUndefined()
       expect(nock.isDone()).toBe(false)
     })


### PR DESCRIPTION
Followup to #16 and #3, this PR flips the conditional to prevent empty commits when no changes would be made, within `updateSection`.

@gr2m does this look as you would expect it to? I opted to just change the conditional instead of actual adding a default value, to keep things simple.

This will be a breaking change, to be published as `v1.0.0`.